### PR TITLE
feat: Webhook GET Fallback (Epic 11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,38 @@ Bot Telegram berbasis AI untuk pencatatan transaksi keuangan otomatis dan pelapo
 2. Jalankan `composer install`.
 3. Copy `.env.example` ke `.env` dan isi API Key Anda.
 4. Jalankan migrasi: `php artisan migrate`.
-5. Daftarkan webhook Telegram Anda.
+5. [Setup Webhook Telegram](#-setup-webhook-telegram).
+6. [Cek Status Bot](#-cek-status-bot).
+
+## 🔗 Setup Webhook Telegram
+
+Bot ini menggunakan metode **Webhook** untuk menerima pesan. Anda harus mendaftarkan URL aplikasi Anda ke Telegram agar Bot bisa merespon.
+
+### Cara 1: Menggunakan Artisan (Direkomendasikan)
+Setelah mengisi `TELEGRAM_BOT_TOKEN` di `.env`, jalankan perintah berikut di terminal:
+```bash
+# Otomatis menggunakan APP_URL dari .env
+php artisan telegram:manage set-webhook
+```
+
+### Cara 2: Manual via Browser
+Buka URL berikut di browser Anda (ganti `<TOKEN>` dan `<DOMAIN>`):
+`https://api.telegram.org/bot<TOKEN>/setWebhook?url=https://<DOMAIN>/api/webhook/telegram`
+
+---
+
+## 🚦 Cek Status Bot
+
+Untuk memastikan Bot dan semua API (Groq/Gemini/Database) berjalan dengan baik, Anda bisa mengeceknya melalui:
+
+1. **Terminal**:
+   ```bash
+   php artisan telegram:manage info
+   php artisan telegram:manage status
+   ```
+
+2. **Browser (API Endpoint)**:
+   Buka `https://domain-anda.com/api/status` untuk melihat laporan kesehatan sistem dalam format JSON.
 
 ## 📂 Struktur Dokumentasi
 - [Panduan Migrasi dari Python](docs/MIGRATION_GUIDE.md)

--- a/app/Http/Controllers/TelegramWebhookController.php
+++ b/app/Http/Controllers/TelegramWebhookController.php
@@ -199,6 +199,18 @@ class TelegramWebhookController extends Controller
     }
 
     /**
+     * Handle GET requests to the webhook URL (fallback for browser visits).
+     */
+    public function verify()
+    {
+        return response()->json([
+            'status' => 'active',
+            'message' => 'Telegram Webhook is Active. This endpoint expects POST requests from Telegram API.',
+            'documentation' => 'https://core.telegram.org/bots/api#setwebhook'
+        ]);
+    }
+
+    /**
      * Log user activity and track message count.
      */
     protected function logActivity(array $message)

--- a/docs/CPANEL_DEPLOYMENT.md
+++ b/docs/CPANEL_DEPLOYMENT.md
@@ -42,7 +42,16 @@ php artisan optimize
 ```
 
 ## 5. Registrasi Webhook Telegram
-Setelah domain aktif, daftarkan URL webhook Anda ke Telegram:
+Setelah domain aktif, Anda harus mendaftarkan URL webhook Anda ke Telegram:
+
+### Cara 1: Via SSH (Rekomendasi)
+Jalankan perintah ini di terminal SSH:
+```bash
+php artisan telegram:manage set-webhook
+```
+
+### Cara 2: Manual via Browser
+Buka URL berikut:
 `https://api.telegram.org/bot<TOKEN>/setWebhook?url=https://domain-anda.com/api/webhook/telegram`
 
 ## 6. Troubleshoot

--- a/issues.md
+++ b/issues.md
@@ -1,8 +1,4 @@
-## Epic 10: Bot Configuration & Health Check
+## Epic 11: Webhook Route Enhancement
+_Tujuan: Memperbaiki user experience saat mengakses route webhook via browser._
 
-_Tujuan: Konfigurasi token, setup webhook, dan validasi Telegram API._
-
-- [ ] **Environment Variables**: Mengisi `TELEGRAM_BOT_TOKEN`, `GROQ_API_KEY`, dan `GEMINI_API_KEY` di dalam file `.env`.
-- [/] **Webhook Setup**: Gunakan `php artisan telegram:manage set-webhook` setelah mengisi .env dan menset APP_URL ke domain publik (ngrok).
-- [/] **API Validation**: Jalankan `php artisan telegram:manage info` dan `status` untuk memvalidasi bot.
-- [ ] **End-to-End Testing**: Melakukan test chat langsung ke bot Telegram untuk memvalidasi alur dari Telegram -> Webhook Laravel -> AI Engine -> Telegram.
+- [ ] **Handle GET Method on Webhook**: Tambahkan fallback route `GET /webhook/telegram` untuk menampilkan pesan "Telegram Webhook is Active" agar tidak muncul error 405 (Method Not Supported) saat tidak sengaja diakses via browser.

--- a/routes/api.php
+++ b/routes/api.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Facades\Route;
 */
 
 Route::get('/status', [StatusController::class, 'index']);
+Route::get('/webhook/telegram', [TelegramWebhookController::class, 'verify']);
 Route::post('/webhook/telegram', [TelegramWebhookController::class, 'handle']);
 
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {


### PR DESCRIPTION
This PR handles \GET\ requests on the Telegram webhook endpoint.
- Added \TelegramWebhookController@verify\.
- Registered \GET /api/webhook/telegram\.
- Returns a JSON status message instead of a Laravel 'Method Not Supported' error page when accessed via browser.