### PR TITLE
feat: implement long polling command for local development (closes #21)

### DIFF
--- a/app/Console/Commands/TelegramPollCommand.php
+++ b/app/Console/Commands/TelegramPollCommand.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Http\Controllers\TelegramWebhookController;
+use App\Services\TelegramService;
+use Illuminate\Console\Command;
+use Illuminate\Http\Request;
+
+class TelegramPollCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'telegram:poll';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Run the Telegram Bot locally using long polling';
+
+    protected TelegramService $telegram;
+    protected TelegramWebhookController $controller;
+
+    public function __construct(TelegramService $telegram, TelegramWebhookController $controller)
+    {
+        parent::__construct();
+        $this->telegram = $telegram;
+        $this->controller = $controller;
+    }
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $this->info("Starting Telegram Bot Polling...");
+        
+        // Remove webhook first to use getUpdates
+        $this->info("Deleting webhook if it exists...");
+        $this->telegram->deleteWebhook();
+
+        $offset = 0;
+        
+        $this->info("Polling updates... (Press Ctrl+C to stop)");
+
+        while (true) {
+            $updates = $this->telegram->getUpdates($offset, 30); // 30 seconds timeout
+            
+            if ($updates && isset($updates['ok']) && $updates['ok']) {
+                foreach ($updates['result'] as $update) {
+                    // Update offset to acknowledge receipt of this update
+                    $offset = $update['update_id'] + 1;
+
+                    // Only process messages
+                    if (isset($update['message'])) {
+                        $this->line("Received message from {$update['message']['from']['first_name']}: " . ($update['message']['text'] ?? ''));
+                        
+                        try {
+                            // Create a dummy request to pass to the controller
+                            $request = new Request([], $update);
+                            
+                            // Process the message using existing webhook controller logic
+                            $this->controller->handle($request);
+                            
+                            $this->info("Processed message ID: {$update['message']['message_id']}");
+                        } catch (\Exception $e) {
+                            $this->error("Error processing message: " . $e->getMessage());
+                        }
+                    }
+                }
+            } else {
+                if ($updates && isset($updates['description'])) {
+                    $this->error("Telegram API Error: " . $updates['description']);
+                }
+            }
+
+            // Small sleep to prevent CPU hogging if it returns immediately
+            usleep(100000); 
+        }
+    }
+}

--- a/app/Services/TelegramService.php
+++ b/app/Services/TelegramService.php
@@ -83,4 +83,39 @@ class TelegramService
             return false;
         }
     }
+
+    /**
+     * Delete the webhook.
+     */
+    public function deleteWebhook(): array|bool
+    {
+        try {
+            $response = Http::post("{$this->baseUrl}/deleteWebhook");
+            return $response->successful() ? $response->json() : false;
+        } catch (\Exception $e) {
+            Log::error("Telegram deleteWebhook Exception: " . $e->getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Get updates (for long polling).
+     */
+    public function getUpdates(int $offset = 0, int $timeout = 30): array|bool
+    {
+        try {
+            // HTTP client timeout must be LONGER than the Telegram long-polling timeout
+            // otherwise cURL will kill the connection before Telegram responds
+            $response = Http::timeout($timeout + 5)
+                ->get("{$this->baseUrl}/getUpdates", [
+                    'offset' => $offset,
+                    'timeout' => $timeout,
+                    'allowed_updates' => ['message']
+                ]);
+            return $response->successful() ? $response->json() : false;
+        } catch (\Exception $e) {
+            Log::error("Telegram getUpdates Exception: " . $e->getMessage());
+            return false;
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Implements the `php artisan telegram:poll` command so the bot can run locally without needing a public HTTPS URL (webhook alternative).

## Changes

### `app/Console/Commands/TelegramPollCommand.php` *(NEW)*
- Artisan command `telegram:poll` for long polling loop
- On start, deletes any active webhook to avoid conflicts
- Polls Telegram every 30 seconds, dispatches received messages to existing `TelegramWebhookController::handle()`

### `app/Services/TelegramService.php`
- Add `deleteWebhook()` — removes active webhook registration
- Add `getUpdates(int $offset, int $timeout)` — fetches updates via long polling with proper HTTP timeout handling (timeout + 5s to avoid cURL cutting connection before Telegram responds)

## Testing
Run the command and send a message from Telegram:
```bash
php artisan telegram:poll
```
Bot will log messages to terminal and respond normally.

## Related
- Closes #21
- Fixes Epic 3 (Deployment Polling in Background) from `issues.md`
